### PR TITLE
Worker Pool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: erlang
+otp_release:
+   - 17.3
+   - 17.0
+   - R16B03-1
+   - R16B02
+   - R16B01

--- a/include/skel.hrl
+++ b/include/skel.hrl
@@ -8,14 +8,15 @@
 -type wf_item()   :: {seq,      worker_fun()}
                    | {pipe,     workflow()}
                    | {ord,      workflow()}
-                   | {farm,     workflow(), pos_integer()}
+                   | {farm,     workflow(), (pos_integer() | {pool, pos_integer()})}
                    | {hyb_farm, workflow(), workflow(), pos_integer(), pos_integer()}
                    | {cluster,  workflow(), decomp_fun(), recomp_fun()}
                    | {map,      workflow()}
                    | {map,      workflow(), pos_integer()}
                    | {hyb_map,  workflow(), workflow(), pos_integer(), pos_integer()}
                    | {reduce,   reduce_fun(), decomp_fun()}
-                   | {feedback, workflow(), filter_fun()}.
+                   | {feedback, workflow(), filter_fun()}
+		   | {pool, workflow(), pos_integer}.
 % Workflow items (skeletons) and their content. 
 
 -type worker_fun()  :: fun((any())        -> any()). % Any function that is performed by a worker unit.

--- a/src/sk_assembler.erl
+++ b/src/sk_assembler.erl
@@ -77,6 +77,9 @@ parse({reduce, Reduce, Decomp}) when is_function(Reduce, 2),
                                      is_function(Decomp, 1) ->
   sk_reduce:make(Decomp, Reduce);
 parse({feedback, WorkFlow, Filter}) when is_function(Filter, 1) ->
-  sk_feedback:make(WorkFlow, Filter).
+    sk_feedback:make(WorkFlow, Filter);
+parse({pool,WorkFlow,NWorkers}) ->
+    sk_pool:make(NWorkers,WorkFlow).
+
 
 

--- a/src/sk_farm.erl
+++ b/src/sk_farm.erl
@@ -1,5 +1,6 @@
 %%%----------------------------------------------------------------------------
 %%% @author Sam Elliott <ashe@st-andrews.ac.uk>
+%%% @author Ramsay Taylor <r.g.taylor@dcs.shef.ac.uk>
 %%% @copyright 2012 University of St Andrews (See LICENCE)
 %%% @headerfile "skel.hrl"
 %%%
@@ -30,9 +31,9 @@
 -spec make((pos_integer()|{pool,pos_integer()}), workflow()) -> maker_fun().
 make({pool,NWorkers}, WorkFlow) ->
   fun(NextPid) ->
-    CollectorPid = spawn(sk_farm_collector, start, [NWorkers, NextPid]),
-    WorkerPids = sk_work_master:reserve(NWorkers,WorkFlow,CollectorPid),
-    spawn(sk_farm_emitter, start, [WorkerPids,true])
+	  CollectorPid = spawn(sk_farm_collector, start, [NWorkers, NextPid]),
+	  WorkerPids = sk_work_master:reserve(NWorkers,WorkFlow,CollectorPid),
+	  spawn(sk_farm_emitter, start, [WorkerPids,true])
   end;
 %% @doc Initialises a Farm skeleton given the number of workers and their 
 %% inner-workflows, respectively.

--- a/src/sk_farm.erl
+++ b/src/sk_farm.erl
@@ -32,7 +32,7 @@ make({pool,NWorkers}, WorkFlow) ->
   fun(NextPid) ->
     CollectorPid = spawn(sk_farm_collector, start, [NWorkers, NextPid]),
     WorkerPids = sk_work_master:reserve(NWorkers,WorkFlow,CollectorPid),
-    spawn(sk_farm_emitter, start, [WorkerPids])
+    spawn(sk_farm_emitter, start, [WorkerPids,true])
   end;
 %% @doc Initialises a Farm skeleton given the number of workers and their 
 %% inner-workflows, respectively.

--- a/src/sk_farm_collector.erl
+++ b/src/sk_farm_collector.erl
@@ -36,9 +36,10 @@ start(NWorkers, NextPid) ->
 loop(NWorkers, NextPid) ->
   receive
     {data, _, _} = DataMessage ->
-      sk_tracer:t(50, self(), NextPid, {?MODULE, data}, [{input, DataMessage}]),
-      NextPid ! DataMessage,
-      loop(NWorkers, NextPid);
+	  io:format("Collected data message ~p~n",[DataMessage]),
+	  sk_tracer:t(50, self(), NextPid, {?MODULE, data}, [{input, DataMessage}]),
+	  NextPid ! DataMessage,
+	  loop(NWorkers, NextPid);
     {system, eos} when NWorkers =< 1 ->
       sk_tracer:t(75, self(), NextPid, {?MODULE, system}, [{msg, eos}, {remaining, 0}]),
       NextPid ! {system, eos},

--- a/src/sk_farm_collector.erl
+++ b/src/sk_farm_collector.erl
@@ -36,7 +36,6 @@ start(NWorkers, NextPid) ->
 loop(NWorkers, NextPid) ->
   receive
     {data, _, _} = DataMessage ->
-	  io:format("Collected data message ~p~n",[DataMessage]),
 	  sk_tracer:t(50, self(), NextPid, {?MODULE, data}, [{input, DataMessage}]),
 	  NextPid ! DataMessage,
 	  loop(NWorkers, NextPid);

--- a/src/sk_farm_emitter.erl
+++ b/src/sk_farm_emitter.erl
@@ -16,7 +16,8 @@
 -module(sk_farm_emitter).
 
 -export([
-         start/1
+         start/1,
+	 start/2
         ]).
 
 -include("skel.hrl").
@@ -43,6 +44,7 @@ loop([Worker|Rest] = Workers, Pool) ->
 	  loop(Rest ++ [Worker],Pool);
     {system, eos} ->
 	  if Pool ->
+		  sk_utils:stop_workers(?MODULE, Workers),
 		  sk_work_master:release(Workers);
 	     true ->
 		  sk_utils:stop_workers(?MODULE, Workers)

--- a/src/sk_farm_emitter.erl
+++ b/src/sk_farm_emitter.erl
@@ -38,14 +38,13 @@ start(Workers, Pool) ->
 loop([Worker|Rest] = Workers, Pool) ->
   receive
     {data, _, _} = DataMessage ->
-	  io:format("Forwarding data message ~p~n",[DataMessage]),
 	  sk_tracer:t(50, self(), Worker, {?MODULE, data}, [{input, DataMessage}]),
 	  Worker ! DataMessage,
 	  loop(Rest ++ [Worker],Pool);
     {system, eos} ->
 	  if Pool ->
 		  sk_utils:stop_workers(?MODULE, Workers),
-		  sk_work_master:release(Workers);
+		  sk_work_master:release_when_idle(Workers);
 	     true ->
 		  sk_utils:stop_workers(?MODULE, Workers)
 	  end

--- a/src/sk_farm_emitter.erl
+++ b/src/sk_farm_emitter.erl
@@ -25,18 +25,26 @@
 %% @doc Initialises the emitter. Sends input as messages to the list of 
 %% processes given by `Workers'.
 start(Workers) ->
-  sk_tracer:t(75, self(), {?MODULE, start}, [{workers, Workers}]),
-  loop(Workers).
+    start(Workers,false).
 
--spec loop([pid(),...]) -> 'eos'.
+start(Workers, Pool) ->
+  sk_tracer:t(75, self(), {?MODULE, start}, [{workers, Workers}]),
+  loop(Workers, Pool).
+
+-spec loop([pid(),...], boolean()) -> 'eos'.
 %% @doc Inner-function to {@link start/1}; recursively captures input, sending %% that input onto the next worker in the list. Ceases only when the halt 
 %% command is received.
-loop([Worker|Rest] = Workers) ->
+loop([Worker|Rest] = Workers, Pool) ->
   receive
     {data, _, _} = DataMessage ->
-      sk_tracer:t(50, self(), Worker, {?MODULE, data}, [{input, DataMessage}]),
-      Worker ! DataMessage,
-      loop(Rest ++ [Worker]);
+	  io:format("Forwarding data message ~p~n",[DataMessage]),
+	  sk_tracer:t(50, self(), Worker, {?MODULE, data}, [{input, DataMessage}]),
+	  Worker ! DataMessage,
+	  loop(Rest ++ [Worker],Pool);
     {system, eos} ->
-      sk_utils:stop_workers(?MODULE, Workers)
+	  if Pool ->
+		  sk_work_master:release(Workers);
+	     true ->
+		  sk_utils:stop_workers(?MODULE, Workers)
+	  end
   end.

--- a/src/sk_peasant.erl
+++ b/src/sk_peasant.erl
@@ -1,6 +1,6 @@
 -module(sk_peasant).
 
--export([start/0,loop/1,work_team/1]).
+-export([start/0,loop/1,work_team/1,get_states/1]).
 
 start() ->
     PID = spawn(?MODULE,loop,[idle]),
@@ -79,8 +79,7 @@ monitor_work_team([]) ->
     ok;
 monitor_work_team(Workers) ->
     timer:sleep(5000),
-    lists:map(fun(W) -> W ! {status,self()} end,Workers),
-    States = collect_states(Workers,[]),
+    States = get_states(Workers),
     io:format("------ Status ------~n"),
     monitor_work_team(lists:foldl(fun({W,State},Acc) ->  
 					  io:format("~p :: ~p~n",[W,State]),
@@ -94,6 +93,10 @@ monitor_work_team(Workers) ->
 				  end,
 				  [],
 				  States)).
+
+get_states(Workers) ->
+    lists:map(fun(W) -> W ! {status,self()} end,Workers),
+    collect_states(Workers,[]).
 
 collect_states([],States) ->
     States;

--- a/src/sk_peasant.erl
+++ b/src/sk_peasant.erl
@@ -23,7 +23,10 @@ loop(idle) ->
 	    From ! {status_report,self(),idle},
 	    loop(idle);
 	terminate ->
-	    ok
+	    ok;
+	{'DOWN', MonitorRef, Type, Object, Info} ->
+	    io:format("DOWN: ~p",[{MonitorRef, Type, Object, Info}]),
+	    loop(idle)
     end;
 loop({Workflow,collector_to_follow}) ->
     receive
@@ -42,8 +45,8 @@ loop({Workflow,SubWorker,Last}) ->
 	terminate ->
 	    SubWorker ! {system, eos},
 	    ok;
-	{system, eos} ->
-	    SubWorker ! {system, eos},
+	{'DOWN', _, _, SubWorker, _} ->
+	    io:format("Worker Down ~p~n",[SubWorker]),
 	    loop(idle);
 	Msg ->
 	    io:format("Passing on ~p~n",[Msg]),

--- a/src/sk_peasant.erl
+++ b/src/sk_peasant.erl
@@ -1,6 +1,6 @@
 -module(sk_peasant).
 
--export([start/0,loop/1]).
+-export([start/0,loop/1,work_team/1]).
 
 start() ->
     PID = spawn(?MODULE,loop,[idle]),
@@ -10,13 +10,18 @@ start() ->
 loop(idle) ->
     receive 
 	{start,Workflow,collector_to_follow} ->
-	    loop({Workflow,collector_to_follow});
+	    loop({Workflow,collector_to_follow,start});
 	{start,Workflow,CollectorPID} ->
 	    SubWorker = sk_utils:start_worker(Workflow,CollectorPID),
+	    monitor(process,SubWorker),
 	    io:format("~p Starting ~p as ~p [output to ~p]~n",[self(),Workflow,SubWorker,CollectorPID]),
-	    loop({Workflow,SubWorker});
+	    loop({Workflow,SubWorker,start});
 	status ->
-	    sk_work_master:find() ! {status_report,self(),idle};
+	    sk_work_master:find() ! {status_report,self(),idle},
+	    loop(idle);
+	{status,From} ->
+	    From ! {status_report,self(),idle},
+	    loop(idle);
 	terminate ->
 	    ok
     end;
@@ -26,10 +31,14 @@ loop({Workflow,collector_to_follow}) ->
 	    SubWorker = sk_utils:start_worker(Workflow,CollectorPID),
 	    loop({Workflow,SubWorker})
     end;
-loop({Workflow,SubWorker}) ->
+loop({Workflow,SubWorker,Last}) ->
     receive
 	status ->
-	    sk_work_master:find() ! {status_report,self(),{working,Workflow}};
+	    sk_work_master:find() ! {status_report,self(),{working,Workflow,Last}},
+	    loop({Workflow,SubWorker,Last});
+	{status,From} ->
+	    From ! {status_report,self(),{working,Workflow,Last}},
+	    loop({Workflow,SubWorker,Last});
 	terminate ->
 	    SubWorker ! {system, eos},
 	    ok;
@@ -39,5 +48,51 @@ loop({Workflow,SubWorker}) ->
 	Msg ->
 	    io:format("Passing on ~p~n",[Msg]),
 	    SubWorker ! Msg,
-	    loop({Workflow,SubWorker})
+	    loop({Workflow,SubWorker,Msg})
     end.
+
+work_team([NumString]) ->
+    net_adm:world(),
+    %% Force names to propagate?...
+    timer:sleep(1000),
+    _Master = global:whereis_name(sk_work_master),
+    io:format("Master: ~p~n",[_Master]),
+    {N,_} = string:to_integer(atom_to_list(NumString)),
+    io:format("~nStarting ~p workers...~n",[N]),
+    Peasants = start_work_team(N,[]),
+    monitor_work_team(Peasants).
+
+start_work_team(N,Team) when N < 1 ->
+    Team;
+start_work_team(N,Team) ->
+    start_work_team(N-1,[start() | Team]).
+
+monitor_work_team([]) ->
+    ok;
+monitor_work_team(Workers) ->
+    timer:sleep(5000),
+    lists:map(fun(W) -> W ! {status,self()} end,Workers),
+    States = collect_states(Workers,[]),
+    monitor_work_team(lists:foldl(fun({W,State},Acc) ->  
+					  io:format("~p :: ~p~n",[W,State]),
+					  case State of
+					      dead ->
+						  sk_work_master:remove(W),
+						  Acc;
+					      _ ->
+						  [W | Acc]
+					  end
+				  end,
+				  [],
+				  States)).
+
+collect_states([],States) ->
+    States;
+collect_states(Workers,States) ->
+    receive
+	{status_report,W,State} ->
+	    collect_states(lists:filter(fun(OW) -> OW /= W end,Workers),[{W,State} | States])
+    after 1000 ->
+	    lists:map(fun(W) -> {W,dead} end, Workers) ++ States
+    end.
+

--- a/src/sk_peasant.erl
+++ b/src/sk_peasant.erl
@@ -1,0 +1,43 @@
+-module(sk_peasant).
+
+-export([start/0,loop/1]).
+
+start() ->
+    PID = spawn(?MODULE,loop,[idle]),
+    sk_work_master:register(PID),
+    PID.
+
+loop(idle) ->
+    receive 
+	{start,Workflow,collector_to_follow} ->
+	    loop({Workflow,collector_to_follow});
+	{start,Workflow,CollectorPID} ->
+	    SubWorker = sk_utils:start_worker(Workflow,CollectorPID),
+	    io:format("~p Starting ~p as ~p [output to ~p]~n",[self(),Workflow,SubWorker,CollectorPID]),
+	    loop({Workflow,SubWorker});
+	status ->
+	    sk_work_master:find() ! {status_report,self(),idle};
+	terminate ->
+	    ok
+    end;
+loop({Workflow,collector_to_follow}) ->
+    receive
+	{set_collector,CollectorPID} ->
+	    SubWorker = sk_utils:start_worker(Workflow,CollectorPID),
+	    loop({Workflow,SubWorker})
+    end;
+loop({Workflow,SubWorker}) ->
+    receive
+	status ->
+	    sk_work_master:find() ! {status_report,self(),{working,Workflow}};
+	terminate ->
+	    SubWorker ! {system, eos},
+	    ok;
+	{system, eos} ->
+	    SubWorker ! {system, eos},
+	    loop(idle);
+	Msg ->
+	    io:format("Passing on ~p~n",[Msg]),
+	    SubWorker ! Msg,
+	    loop({Workflow,SubWorker})
+    end.

--- a/src/sk_peasant.erl
+++ b/src/sk_peasant.erl
@@ -68,13 +68,6 @@ loop(Workflow,SubWorker,Last,CollectorPID) ->
 	{status,From} ->
 	    From ! {status_report,self(),{working,Workflow,Last}},
 	    loop(Workflow,SubWorker,Last,CollectorPID);
-	terminate ->
-	    SubWorker ! {system, eos},
-	    ok;
-%%	{'DOWN', _, _, SubWorker, _} ->
-%%	    io:format("[~p] Worker Finished ~p~n",[self(),SubWorker]),
-%%	    sk_work_master:find() ! {job_complete,self()},
-%%	    loop(idle);
 	{'EXIT', SubWorker, Info} ->
 	    io:format("[~p] Worker EXIT: ~p",[self(),{SubWorker, Info}]),
 	    sk_work_master:find() ! {worker_error,self(),Info},

--- a/src/sk_peasant.erl
+++ b/src/sk_peasant.erl
@@ -138,7 +138,7 @@ monitor_work_team(Workers) ->
 					  end
 				  end,
 				  [],
-				  States)).
+				  lists:sort(States))).
 
 -spec get_states(list(pid())) -> list({pid(),any()}).
 get_states(Workers) ->

--- a/src/sk_pool.erl
+++ b/src/sk_pool.erl
@@ -24,7 +24,8 @@ make(NWorkers, WorkFlow) ->
   fun(NextPid) ->
 	  WorkerPids = sk_work_master:reserve(NWorkers,WorkFlow,collector_to_follow),
 	  EmitterPid = spawn(sk_pool_emitter, start, [WorkerPids]),
-	  CollectorPid = spawn(sk_pool_collector, start, [NWorkers, EmitterPid, NextPid]),
+	  %% Use length(WorkerPids) because reserve now supports {max,N} requests, so the numebr of workers could vary
+	  CollectorPid = spawn(sk_pool_collector, start, [length(WorkerPids), EmitterPid, NextPid]),
 	  lists:map(fun(W) -> W ! {set_collector,CollectorPid} end, WorkerPids),
 	  EmitterPid
   end.

--- a/src/sk_pool.erl
+++ b/src/sk_pool.erl
@@ -1,0 +1,32 @@
+%%%----------------------------------------------------------------------------
+%%% @author Ramsay Taylor <r.g.taylor@sheffield.ac.uk>
+%%%
+%%% @doc This module contains the pool skeleton - a work farmer for unbalanced clusters
+%%%
+%%% This skeleton requests a number of worker processes from the sk_work_master. It then
+%%% allocates one job to each worker and waits for it to complete. As each worker completes
+%%% its task it is assigned another. This allows more tasks to be assigned to faster workers.
+%%%
+%%% This assumes that the tasks themselves take a long time relative to reporting their completion
+%%% and assigning new tasks. For short tasks it may be more efficient to use sk_farm, or to combine
+%%% tasks into blocks.
+%%%
+%%% @end
+%%%----------------------------------------------------------------------------
+-module(sk_pool).
+
+-export([make/2]).
+
+-include("skel.hrl").
+
+-spec make((pos_integer()|{exactly,pos_integer()}|{max,pos_integer()}), workflow()) -> maker_fun().
+make(NWorkers, WorkFlow) ->
+  fun(NextPid) ->
+	  WorkerPids = sk_work_master:reserve(NWorkers,WorkFlow,collector_to_follow),
+	  EmitterPid = spawn(sk_pool_emitter, start, [WorkerPids]),
+	  CollectorPid = spawn(sk_pool_collector, start, [NWorkers, EmitterPid, NextPid]),
+	  lists:map(fun(W) -> W ! {set_collector,CollectorPid} end, WorkerPids),
+	  EmitterPid
+  end.
+
+

--- a/src/sk_pool_emitter.erl
+++ b/src/sk_pool_emitter.erl
@@ -1,0 +1,56 @@
+%%%----------------------------------------------------------------------------
+%%% @author Ramsay Taylor <r.g.taylor@sheffield.ac.uk>
+%%%
+%%% @doc This module contains the emitter for the pool skeleton.
+%%%
+%%% This emitter retains most of the data and releases one item to each worker
+%%% when the sk_pool_collector reports the recipt of the previous result from
+%%% that worker.
+%%%
+%%% @end
+%%%----------------------------------------------------------------------------
+-module(sk_pool_emitter).
+-export([start/1]).
+
+-include("skel.hrl").
+
+-spec start([pid(),...]) -> 'eos'.
+start(Workers) ->
+    sk_tracer:t(75, self(), {?MODULE, start}, [{workers, Workers}]),
+    loop(Workers,[],[]).
+
+-spec loop(list(pid()), list(pid()), list()) -> 'eos'.
+loop(Idle,Busy,Work) ->
+    receive
+	{data, _, _} = DataMessage ->
+	    case Idle of
+		[] ->
+		    loop(Idle,Busy,Work ++ [DataMessage]);
+		[I | Is] ->
+		    sk_tracer:t(50, self(), I, {?MODULE, data}, [{input, DataMessage}]),
+		    I ! DataMessage,
+		    loop(Is,[I | Busy],Work)
+	    end;
+	{system,eos} ->
+	    lists:map(fun(W) -> W ! {system,eos} end, Idle),
+	    sk_work_master:release(Idle),
+	    loop([], Busy, Work ++ [{system,eos}]);
+	{complete,WPID} ->
+	    case Work of
+		[] ->
+		    loop([WPID | Idle], lists:filter(fun(W) -> W /= WPID end, Busy), Work);
+		[{system,eos}] ->
+		    WPID ! {system,eos},
+		    sk_work_master:release([WPID]),
+		    case Busy of
+			[] ->
+			    ok;
+			_ ->
+			    loop([],Busy,Work)
+		    end;
+		[D | MoreWork] ->
+		    sk_tracer:t(50, self(), WPID, {?MODULE, data}, [{input, D}]),
+		    WPID ! D,
+		    loop(Idle,Busy,MoreWork)
+	    end
+	end.

--- a/src/sk_work_master.erl
+++ b/src/sk_work_master.erl
@@ -1,0 +1,60 @@
+-module(sk_work_master).
+
+-export([reserve/3,release/1,register/1,find/0,loop/2]).
+
+start() ->
+    PID = spawn(?MODULE,loop,[[],[]]),
+    yes = global:register_name(sk_work_master,PID),
+    PID.
+
+find() ->
+    case global:whereis_name(sk_work_master) of
+	undefined ->
+	    start();
+	PID ->
+	    PID
+    end.
+
+loop(Free,Assigned) ->
+    receive
+	{reserve,NWorkers,Workflow,CollectorPID,From} ->
+	    if length(Free) >= NWorkers ->
+		    {Workers, NewFree} = lists:split(NWorkers,Free),
+		    lists:map(fun(W) -> W ! {start,Workflow,CollectorPID} end,Workers),
+		    From ! {ok,Workers},
+		    io:format("Reserving ~p workers, now ~p Free, ~p Assigned~n",[length(Workers),length(NewFree), length(Workers) + length(Assigned)]),
+		    loop(NewFree,Assigned ++ Workers);
+	       true ->
+		    io:format("Requested ~p workers but only ~p available~n",[NWorkers,length(Free)]),
+		    From ! not_enough_workers,
+		    loop(Free,Assigned)
+	    end;
+	{release,Workers} ->
+	    lists:map(fun(W) -> W ! stop end,Workers),
+	    NewAssigned = lists:filter(fun(A) -> not lists:any(fun(W) -> A == W end, Workers) end, Assigned),
+	    io:format("Releasing ~p workers, now ~p Free, ~p Assigned~n",[length(Workers),length(Free) + length(Workers), length(NewAssigned)]),
+	    loop(Free ++ Workers, NewAssigned);
+	{register,WorkerPID} ->
+	    io:format("Registering new peasant ~p~n",[WorkerPID]),
+	    loop([WorkerPID | Free],Assigned);
+	Other ->
+	    io:format("Unexpected message to work master:~n~p~n",[Other]),
+	    loop(Free,Assigned)
+    end.
+
+register(WorkerPID) ->
+    find() ! {register,WorkerPID}.
+
+reserve(NWorkers,Workflow,CollectorPID) ->
+    io:format("Attempting to reserve ~p workers from ~p~n~p~n~p~n",[NWorkers,find(),Workflow,CollectorPID]),
+    find() ! {reserve,NWorkers,Workflow,CollectorPID,self()},
+    receive
+	{ok,Workers} ->
+	    Workers;
+	not_enough_workers ->
+	    timer:sleep(1000),
+	    reserve(NWorkers,Workflow,CollectorPID)
+    end.
+
+release(Workers) ->
+    find() ! {release,Workers}.

--- a/src/sk_work_master.erl
+++ b/src/sk_work_master.erl
@@ -50,7 +50,7 @@ loop(Free,Assigned) ->
 	       true ->
 		    io:format("Requested ~p workers but only ~p available~n",[NWorkers,length(Free)]),
 		    From ! {not_enough_workers,length(Free)},
-		    loop(Free,Assigned)
+		    loop(CleanFree,CleanAssigned)
 	    end;
 	{release,Workers} ->
 	    lists:map(fun(W) -> W ! stop end,Workers),

--- a/src/sk_work_master.erl
+++ b/src/sk_work_master.erl
@@ -49,7 +49,7 @@ loop(Free,Assigned) ->
 		    loop(NewFree,CleanAssigned ++ Workers);
 	       true ->
 		    io:format("Requested ~p workers but only ~p available~n",[NWorkers,length(Free)]),
-		    From ! {not_enough_workers,length(Free)},
+		    From ! {not_enough_workers,length(CleanFree)},
 		    loop(CleanFree,CleanAssigned)
 	    end;
 	{release,Workers} ->

--- a/src/sk_work_master.erl
+++ b/src/sk_work_master.erl
@@ -1,12 +1,33 @@
+%%%----------------------------------------------------------------------------
+%%% @author Ramsay Taylor <r.g.taylor@sheffield.ac.uk>
+%%%
+%%% @doc This module contains the work master, which manages the worker pool
+%%%
+%%% The sk_work_master process will run on whichever node is first to call
+%%% sk_work_master:find(). Thereafter, find() will return the PID of that process.
+%%%
+%%% The work master receives register requests from 'peasants' and manintains
+%%% lists of free and assigned peasants. Free peasants can be reserved and released
+%%% with the relevant API calls.
+%%%
+%%% The work master periodically checks the health of peasants and removes 'dead'
+%%% ones from the lists.
+%%%
+%%% @end
+%%%----------------------------------------------------------------------------
 -module(sk_work_master).
 
--export([reserve/3,release/1,release_when_idle/1,register/1,remove/1,find/0,loop/2]).
+-export([reserve/3,release/1,release_when_idle/1,register/1,remove/1,find/0,loop/2,status/0,stop/0]).
 
+-include("skel.hrl").
+
+-spec start() -> pid().
 start() ->
     PID = spawn(?MODULE,loop,[[],[]]),
     yes = global:register_name(sk_work_master,PID),
     PID.
 
+-spec find() -> pid().
 find() ->
     case global:whereis_name(sk_work_master) of
 	undefined ->
@@ -15,6 +36,7 @@ find() ->
 	    PID
     end.
 
+-spec loop(list(pid),list(pid)) -> ok.
 loop(Free,Assigned) ->
     receive
 	{reserve,NWorkers,Workflow,CollectorPID,From} ->
@@ -45,6 +67,14 @@ loop(Free,Assigned) ->
 		_ ->
 		    loop(lists:filter(fun(W) -> W /= WorkerPID end,Free), Assigned)
 	    end;
+	terminate ->
+	    lists:map(fun(W) -> W ! terminate end, Free ++ Assigned),
+	    ok;
+%%	{job_complete,WorkerPID} ->
+%%	    loop(Free,Assigned);
+	{status, From} ->
+	    From ! {sk_work_master_status,length(Free),length(Assigned)},
+	    loop(Free,Assigned);
 	Other ->
 	    io:format("Unexpected message to work master:~n~p~n",[Other]),
 	    loop(Free,Assigned)
@@ -70,9 +100,12 @@ cleanup_dead(Free,Assigned) ->
     {lists:filter(fun(W) -> lists:member(W,Alive) end, Free),
      lists:filter(fun(W) -> lists:member(W,Alive) end, Assigned)}.
 
+-spec register(pid()) -> ok.
 register(WorkerPID) ->
-    find() ! {register,WorkerPID}.
+    find() ! {register,WorkerPID},
+    ok.
 
+-spec reserve(pos_integer(),workflow(),pid()) -> list(pid()).
 reserve(NWorkers,Workflow,CollectorPID) ->
     find() ! {reserve,NWorkers,Workflow,CollectorPID,self()},
     receive
@@ -83,12 +116,30 @@ reserve(NWorkers,Workflow,CollectorPID) ->
 	    reserve(NWorkers,Workflow,CollectorPID)
     end.
 
+-spec release(list(pid())) -> ok.
 release(Workers) ->
-    find() ! {release,Workers}.
+    find() ! {release,Workers},
+    ok.
 
+-spec release_when_idle(list(pid)) -> ok.
 release_when_idle(Workers) ->
     lists:map(fun(W) -> W ! release_when_idle end, Workers),
     ok.
 
+-spec remove(pid()) -> ok.
 remove(WorkerPID) ->
-    find() ! {remove,WorkerPID}.
+    find() ! {remove,WorkerPID},
+    ok.
+
+-spec status() -> {pos_integer(),pos_integer()}.
+status() ->
+    sk_work_master:find() ! {status, self()},
+    receive
+	{sk_work_master_status,FreeN,AssignedN} ->
+	    {FreeN,AssignedN}
+    end.
+
+-spec stop() -> ok.
+stop() ->
+    sk_work_master:find() ! terminate,
+    ok.

--- a/src/sk_work_master.erl
+++ b/src/sk_work_master.erl
@@ -112,7 +112,12 @@ reserve({max,NWorkers},Workflow,CollectorPID) ->
 	{ok,Workers} ->
 	    Workers;
 	{not_enough_workers,Avail} ->
-	    reserve(Avail,Workflow,CollectorPID)
+	    if Avail > 0 ->
+		    reserve(Avail,Workflow,CollectorPID);
+	       true ->
+		    timer:sleep(1000),
+		    reserve({max,NWorkers},Workflow,CollectorPID)
+	    end
     end;
 reserve(NWorkers,Workflow,CollectorPID) ->
     find() ! {reserve,NWorkers,Workflow,CollectorPID,self()},

--- a/src/sk_work_master.erl
+++ b/src/sk_work_master.erl
@@ -106,6 +106,9 @@ register(WorkerPID) ->
     ok.
 
 -spec reserve(pos_integer() | {max,pos_integer()},workflow(),pid()) -> list(pid()).
+reserve({max,0},_Workflow,_CollectorPID) ->
+    %% This is dumb, but there might be a use for it somewhere.
+    [];
 reserve({max,NWorkers},Workflow,CollectorPID) ->
     find() ! {reserve,NWorkers,Workflow,CollectorPID,self()},
     receive

--- a/src/sk_work_master.erl
+++ b/src/sk_work_master.erl
@@ -1,6 +1,6 @@
 -module(sk_work_master).
 
--export([reserve/3,release/1,register/1,remove/1,find/0,loop/2]).
+-export([reserve/3,release/1,release_when_idle/1,register/1,remove/1,find/0,loop/2]).
 
 start() ->
     PID = spawn(?MODULE,loop,[[],[]]),
@@ -66,6 +66,10 @@ reserve(NWorkers,Workflow,CollectorPID) ->
 
 release(Workers) ->
     find() ! {release,Workers}.
+
+release_when_idle(Workers) ->
+    lists:map(fun(W) -> W ! release_when_idle end, Workers),
+    ok.
 
 remove(WorkerPID) ->
     find() ! {remove,WorkerPID}.


### PR DESCRIPTION
This implements the "worker pool" approach. 

Workers can be spawned anywhere in the cluster and they register themselves with the sk_work_master. Thereafter, any skeletons that use the {pool,Skel,Num} structure get assigned Num workers (or wait until Num are available) and then the Skel job is distributed across the workers. The workers receive work and report back, at which point they are assigned more work.

It also supports {pool,Skel,{max,Num}} which will assign either Num or as many workers as are currently free (minimum 1). 

This is effective in cases where a) The cost of communicating the data across the cluster is small compared to the processing, and/or b) there is a significant miss-match between job sizes.